### PR TITLE
🚀 Upgrades for typst 0.13.0

### DIFF
--- a/scripts/typst.js
+++ b/scripts/typst.js
@@ -79,7 +79,7 @@ async function buildIcons(package, style) {
       return [
         `// ${icon.name}`,
         `#let ${icon.name}-svg = \`\`\`${svg}\`\`\`.text`,
-        `#let ${icon.name}-icon(color: black, height: 1.1em, baseline: 13.5%) = {\n  box(height: height, baseline: baseline, image.decode(${icon.name}-svg.replace("currentColor", color.to-hex())))\n}`,
+        `#let ${icon.name}-icon(color: black, height: 1.1em, baseline: 13.5%) = {\n  box(height: height, baseline: baseline, image(bytes(${icon.name}-svg.replace("currentColor", color.to-hex()))))\n}`,
       ].join('\n');
     })
     .join('\n\n');


### PR DESCRIPTION
`image.decode(str)` --> `image(bytes(str))`

Fixes https://github.com/continuous-foundation/pubmatter/issues/10