### PR TITLE
Fix SVG syntax in typst

### DIFF
--- a/scripts/typst.js
+++ b/scripts/typst.js
@@ -78,7 +78,7 @@ async function buildIcons(package, style) {
       const svg = icon.svg.replaceAll('\n', '');
       return [
         `// ${icon.name}`,
-        `#let ${icon.name}-svg = \`\`\`${svg}\`\`\`.text`,
+        `#let ${icon.name}-svg = \`\`\`svg ${svg}\`\`\`.text`,
         `#let ${icon.name}-icon(color: black, height: 1.1em, baseline: 13.5%) = {\n  box(height: height, baseline: baseline, image(bytes(${icon.name}-svg.replace("currentColor", color.to-hex()))))\n}`,
       ].join('\n');
     })


### PR DESCRIPTION
The following line causes the package to error in the current typst development version:

```typ
#let ${icon.name}-svg = ```${svg}```.text
```

From the typst docs:
> When you use three or more backticks, you can additionally specify a language tag for syntax highlighting directly after the opening backticks. Within raw blocks, everything (except for the language tag, if applicable) is rendered as is, in particular, there are no escape sequences.

While ignored as invalid tag in the current typst release, in the next release everything until the first whitespace is considered a language tag, thus the `<svg` at the beginning is treated as language tag and stripped, causing an error "Failed to parse SVG". See https://github.com/typst/typst/pull/7337 where this behaviour was introduced.

To fix this, this PR adds an explicit language tag (this is backwards compatible to earlier versions).

# Issue reproduction example:
```typ
#import "@preview/scienceicons:0.1.0": *
#orcid-svg
#orcid-icon()
```

Selection Compiler "Development Version (1. April 2026)" in the settings on typst.app gives:
<img width="593" height="242" alt="Screenshot" src="https://github.com/user-attachments/assets/1cf27ff2-5b54-4400-9c93-25eb8b97c480" />

